### PR TITLE
Configurable advertising types

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -72,6 +72,13 @@ var LE_LTK_NEG_REPLY_CMD = OCF_LE_LTK_NEG_REPLY | OGF_LE_CTL << 10;
 
 var HCI_OE_USER_ENDED_CONNECTION = 0x13;
 
+// See Bluetooth-Core 5.0 Host Controller Interface Functional Specification
+// "LE Set Advertising Parameters Command"
+var ADV_IND = 0x00; // Connectable and scannable
+var ADV_DIRECT_IND = 0x01; // Connectable high duty cycle directed advertising
+var ADV_SCAN_IND = 0x02; // Scannable undirected advertising
+var ADV_NONCONN_IND = 0x03; // Non connectable unidirected avertising
+
 var STATUS_MAPPER = require('./hci-status');
 
 var Hci = function() {
@@ -283,11 +290,12 @@ Hci.prototype.setAdvertisingParameters = function() {
   cmd.writeUInt8(15, 3);
 
   var advertisementInterval = Math.floor((process.env.BLENO_ADVERTISING_INTERVAL ? parseFloat(process.env.BLENO_ADVERTISING_INTERVAL) : 100) * 1.6);
+  var adv_type = process.env.BLENO_ADVERTISING_TYPE ? parseInt(process.env.BLENO_ADVERTISING_TYPE) : ADV_IND;
 
   // data
   cmd.writeUInt16LE(advertisementInterval, 4); // min interval
   cmd.writeUInt16LE(advertisementInterval, 6); // max interval
-  cmd.writeUInt8(0x00, 8); // adv type
+  cmd.writeUInt8(adv_type, 8); // adv type
   cmd.writeUInt8(0x00, 9); // own addr typ
   cmd.writeUInt8(0x00, 10); // direct addr type
   (new Buffer('000000000000', 'hex')).copy(cmd, 11); // direct addr


### PR DESCRIPTION
Set BLENO_ADVERTISING_INTERVAL as an env variable to the advertising type
you wish to use as defined in the HCI specification.